### PR TITLE
Call `monin_obukhov_stable_mix` from `stable_mix_1d`

### DIFF
--- a/monin_obukhov/include/monin_obukhov.inc
+++ b/monin_obukhov/include/monin_obukhov.inc
@@ -111,34 +111,16 @@ subroutine STABLE_MIX_3D_(rich, mix)
 
 real(kind=FMS_MO_KIND_), intent(in) , dimension(:,:,:)  :: rich
 real(kind=FMS_MO_KIND_), intent(out), dimension(:,:,:)  :: mix
+integer                                                 :: n2, n3, i, j
 
-integer                                                 :: n, ier, m, i, j , k
-real(kind=FMS_MO_KIND_), dimension(:), allocatable      :: rich1d
-real(kind=FMS_MO_KIND_), dimension(:), allocatable      :: mix1d
-integer, parameter                                      :: lkind = FMS_MO_KIND_
+n2 = size(mix, 2)
+n3 = size(mix, 3)
 
-if(.not.module_is_initialized) call error_mesg('stable_mix_3d in monin_obukhov_mod', &
-     'monin_obukhov_init has not been called', FATAL)
-
-n = size(rich,1)*size(rich,2)*size(rich,3)
-  allocate(rich1d(n), mix1d(n))
-  rich1d = 0.0_lkind
-  mix1d = 0.0_lkind
-
-  do k = 1, size(rich,3)
-    do j = 1, size(rich,2)
-      do i = 1, size(rich,1)
-        rich1d(m) = rich(i, j, k)
-        mix1d(m) = mix(i, j, k)
-        m = m+1
-      end do
-    end do
-  end do
-
-call monin_obukhov_stable_mix(stable_option, real(rich_crit, FMS_MO_KIND_), real(zeta_trans, FMS_MO_KIND_), &
-     & n, real(rich1d, FMS_MO_KIND_), mix1d, ier)
-
-
+do j=1,n3
+  do i=1,n2
+    call stable_mix(rich(:, i, j), mix(:, i, j))
+  enddo
+enddo
 
 end subroutine STABLE_MIX_3D_
 
@@ -819,14 +801,13 @@ subroutine STABLE_MIX_2D_(rich, mix)
 
 real(kind=FMS_MO_KIND_), intent(in) , dimension(:,:)  :: rich
 real(kind=FMS_MO_KIND_), intent(out), dimension(:,:)  :: mix
+integer :: i, n2
 
-real(kind=FMS_MO_KIND_), dimension(size(rich,1),size(rich,2),1) :: rich_3d, mix_3d
+n2 = size(mix, 2)
 
-rich_3d(:,:,1) = rich
-
-call stable_mix(rich_3d, mix_3d)
-
-mix = mix_3d(:,:,1)
+do i=1,n2
+  call stable_mix(rich(:, i), mix(:, i))
+enddo
 
 return
 end subroutine STABLE_MIX_2D_
@@ -838,16 +819,16 @@ subroutine STABLE_MIX_1D_(rich, mix)
 
 real(kind=FMS_MO_KIND_), intent(in) , dimension(:)  :: rich
 real(kind=FMS_MO_KIND_), intent(out), dimension(:)  :: mix
+integer :: n, ier
 
-real(kind=FMS_MO_KIND_), dimension(size(rich),1,1) :: rich_3d, mix_3d
+if(.not.module_is_initialized) call error_mesg('stable_mix_1d in monin_obukhov_mod', &
+     'monin_obukhov_init has not been called', FATAL)
 
-rich_3d(:,1,1) = rich
+n = size(mix)
 
-call stable_mix(rich_3d, mix_3d)
+call monin_obukhov_stable_mix(stable_option, real(rich_crit, FMS_MO_KIND_), real(zeta_trans, FMS_MO_KIND_), &
+     & n, rich, mix, ier)
 
-mix = mix_3d(:,1,1)
-
-return
 end subroutine STABLE_MIX_1D_
 
 !=======================================================================
@@ -857,15 +838,12 @@ subroutine STABLE_MIX_0D_(rich, mix)
 real(kind=FMS_MO_KIND_), intent(in)       :: rich
 real(kind=FMS_MO_KIND_), intent(out)      :: mix
 
-real(kind=FMS_MO_KIND_), dimension(1,1,1) :: rich_3d, mix_3d
+real(kind=FMS_MO_KIND_), dimension(1) :: mix_1d
 
-rich_3d(1,1,1) = rich
+call stable_mix([rich], mix_1d)
 
-call stable_mix(rich_3d, mix_3d)
+mix = mix_1d(1)
 
-mix = mix_3d(1,1,1)
-
-return
 end subroutine STABLE_MIX_0D_
 !=======================================================================
 

--- a/monin_obukhov/include/monin_obukhov.inc
+++ b/monin_obukhov/include/monin_obukhov.inc
@@ -39,9 +39,7 @@ if(.not.module_is_initialized) call error_mesg('mo_drag_1d in monin_obukhov_mod'
      'monin_obukhov_init has not been called', FATAL)
 
 n      = size(pt)
-lavail = .false.
-if(present(avail)) lavail = .true.
-
+lavail = present(avail)
 
 if(lavail) then
    if (count(avail) .eq. 0) return
@@ -59,7 +57,7 @@ call monin_obukhov_drag_1d(real(grav, FMS_MO_KIND_), real(vonkarm, FMS_MO_KIND_)
         & real(drag_min_heat, FMS_MO_KIND_), real(drag_min_moist, FMS_MO_KIND_), real(drag_min_mom, FMS_MO_KIND_),  &
         & n, real(pt, FMS_MO_KIND_), real(pt0, FMS_MO_KIND_), real(z, FMS_MO_KIND_), real(z0, FMS_MO_KIND_), &
         & real(zt, FMS_MO_KIND_), real(zq, FMS_MO_KIND_), real(speed, FMS_MO_KIND_), drag_m, drag_t,         &
-        & drag_q, u_star, b_star, lavail, avail, ier)
+        & drag_q, u_star, b_star, lavail, avail_dummy, ier)
 endif
 
 end subroutine MO_DRAG_1D_


### PR DESCRIPTION
Restructure the subroutines in the `stable_mix` interface of `monin_obukhov_mod` so that `stable_mix_1d` calls `monin_obukhov_stable_mix`, which is the underlying implementation. `stable_mix_2d` and `stable_mix_3d` now call `stable_mix_1d` on 1D slices of the data.